### PR TITLE
WIP: Refacto match case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 # import
 __pycache__
 
+# Pycharm
+.idea

--- a/cogs/ufd.py
+++ b/cogs/ufd.py
@@ -36,6 +36,7 @@ class UFD(commands.Cog, HelperCommand, ParseArgs):
         if command == "list":
             subcommand = self._select_subcommand(arguments=args)
 
+            # TODO: refactor this using match-case once 3.10 is out & stable
             if subcommand == "char":
                 all_embed_m = self.char_typecommand(arguments=args)
                 for embed_m in all_embed_m:

--- a/cogs/ufd.py
+++ b/cogs/ufd.py
@@ -51,8 +51,8 @@ class UFD(commands.Cog, HelperCommand, ParseArgs):
 
             else:
                 await ctx.channel.send((
-                    "Unrecognezied command: make sure you're choosing"
-                    "between {'char', 'moves', 'index'}"))
+                    "Unrecognized command: make sure you're choosing"
+                    "between 'char', 'moves', 'index'"))
                 return
 
         else:
@@ -125,7 +125,7 @@ class UFD(commands.Cog, HelperCommand, ParseArgs):
         return [discord.Embed(title=title, description=m) for m in send_messages]
 
     @staticmethod
-    def _select_subcommand(arguments: list):
+    def _select_subcommand(arguments):
         if len(arguments) == 0:
             return "char"
         return arguments[0]


### PR DESCRIPTION
python 3.10 introduit le [match-case](https://docs.python.org/3.10/whatsnew/3.10.html#pep-634-structural-pattern-matching) et donc on pourra facilement refacto les if/elif enchainé avec une structure type switch, plus joli, intuitif et pratique.